### PR TITLE
Fix for a createable value when Enter is pressed

### DIFF
--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -341,8 +341,8 @@ export const Select: FC<Partial<SelectProps>> = ({
 
       if (index > -1 || createable) {
         const newSelection = {
-          value: result[index]?.value,
-          children: result[index]?.value
+          value: createable ? result[index]?.value : inputValue,
+          children: createable ? result[index]?.value : inputValue,
         };
 
         toggleSelectedOption(newSelection);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
When typing into the Select field and hitting enter, the value passed to the component is undefined.  This is because no value is selected, so the selected index will be -1, causing `result[index]` to be undefined.

Issue Number: N/A


## What is the new behavior?
If `createable` is true, then the new Select entry will be populated by the text typed by the user.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
